### PR TITLE
docs: streamline project documentation for v0.2.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,198 +1,27 @@
-# DEPAAD Environment Configuration Template
+# DEPAAD Environment Configuration
 # Copy this file to .env and fill in your actual values
 # DO NOT commit .env to version control
 
 # =============================================================================
-# AZURE ACTIVE DIRECTORY CONFIGURATION
+# REQUIRED CONFIGURATION
 # =============================================================================
-
-# Azure AD Application (Client) ID
-# Get this from Azure Portal > App Registrations > Your App > Overview
-CLIENT_ID=98145980-4a60-455a-9699-eacf4d339ee8
 
 # Azure AD Client Secret (REQUIRED)
-# Generate this from Azure Portal > App Registrations > Your App > Certificates & secrets
-# Keep this secret secure and rotate regularly
+# Generate from Azure Portal > App Registrations > Your App > Certificates & secrets
 CLIENT_SECRET=your_azure_ad_client_secret_here
-
-# Azure AD Tenant Authority URL
-# Format: https://login.microsoftonline.com/{tenant-id}
-# For multi-tenant: https://login.microsoftonline.com/common
-AUTHORITY=https://login.microsoftonline.com/935ddf29-4b2b-4c23-8b83-b4dd0645ca6b
-
-# OAuth2 Scopes (space-separated)
-# Example: User.Read User.ReadBasic.All
-SCOPE=
-
-# =============================================================================
-# MOBILEIRON CLOUD CONFIGURATION
-# =============================================================================
 
 # MobileIron Cloud API Token (REQUIRED)
 # Generate from MobileIron Admin Portal > Admin > API > Generate Token
 # Must be Base64 encoded: echo -n "username:password" | base64
 API_TOKEN=your_base64_encoded_mobileiron_token_here
 
-# MobileIron Cloud Host URL
-# Example: https://na2.mobileiron.com, https://eu1.mobileiron.com
-UEMHOST=https://na2.mobileiron.com
-
-# MobileIron API Version
-# Options: Cloud, Core, Connected Cloud
-MI_API_TYPE=Cloud
-
 # =============================================================================
-# FLASK APPLICATION CONFIGURATION
+# OPTIONAL CONFIGURATION
 # =============================================================================
 
-# Flask Environment
-# Options: development, testing, production
-FLASK_ENV=production
+# Flask Environment (default: production)
+# FLASK_ENV=production
 
-# Flask Debug Mode (NEVER enable in production)
-# Options: True, False
-FLASK_DEBUG=False
-
-# Flask Secret Key (REQUIRED for production)
+# Flask Secret Key (recommended for production)
 # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
-SECRET_KEY=your_flask_secret_key_generate_random_32_chars
-
-# Session Configuration
-SESSION_TYPE=filesystem
-SESSION_PERMANENT=False
-SESSION_USE_SIGNER=True
-
-# =============================================================================
-# SECURITY CONFIGURATION
-# =============================================================================
-
-# Session Cookie Settings
-SESSION_COOKIE_SECURE=True
-SESSION_COOKIE_HTTPONLY=True
-SESSION_COOKIE_SAMESITE=Lax
-
-# CSRF Protection
-WTF_CSRF_ENABLED=True
-WTF_CSRF_TIME_LIMIT=3600
-
-# Rate Limiting (requests per minute)
-RATELIMIT_DEFAULT=100
-
-# =============================================================================
-# LOGGING CONFIGURATION
-# =============================================================================
-
-# Log Level
-# Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
-LOG_LEVEL=INFO
-
-# Log File Path
-LOG_FILE=logs/depaad.log
-
-# Log Rotation
-LOG_MAX_BYTES=1048576
-LOG_BACKUP_COUNT=10
-
-# =============================================================================
-# MONITORING & OBSERVABILITY
-# =============================================================================
-
-# Application Monitoring
-SENTRY_DSN=your_sentry_dsn_for_error_tracking
-
-# Performance Monitoring
-NEW_RELIC_LICENSE_KEY=your_new_relic_license_key
-
-# Health Check Configuration
-HEALTH_CHECK_ENABLED=True
-
-# =============================================================================
-# DEPLOYMENT CONFIGURATION
-# =============================================================================
-
-# Server Configuration
-PORT=5000
-HOST=0.0.0.0
-
-# Gunicorn Configuration (for production)
-WORKERS=4
-TIMEOUT=30
-KEEPALIVE=5
-
-# =============================================================================
-# DEVELOPMENT CONFIGURATION
-# =============================================================================
-
-# Development Database (if needed)
-DATABASE_URL=sqlite:///dev.db
-
-# Testing Configuration
-TESTING=False
-WTF_CSRF_ENABLED=False
-
-# =============================================================================
-# EXTERNAL INTEGRATIONS
-# =============================================================================
-
-# SMTP Configuration (for notifications)
-MAIL_SERVER=smtp.company.com
-MAIL_PORT=587
-MAIL_USE_TLS=True
-MAIL_USERNAME=noreply@company.com
-MAIL_PASSWORD=your_smtp_password
-
-# Webhook URLs (for notifications)
-SLACK_WEBHOOK_URL=https://hooks.slack.com/services/your/webhook/url
-TEAMS_WEBHOOK_URL=https://company.webhook.office.com/your/webhook/url
-
-# =============================================================================
-# COMPLIANCE & AUDIT
-# =============================================================================
-
-# Audit Logging
-AUDIT_LOG_ENABLED=True
-AUDIT_LOG_FILE=logs/audit.log
-
-# Data Retention (days)
-SESSION_RETENTION_DAYS=30
-LOG_RETENTION_DAYS=90
-
-# Privacy Settings
-GDPR_COMPLIANCE=True
-DATA_ENCRYPTION_KEY=your_data_encryption_key_32_chars
-
-# =============================================================================
-# FEATURE FLAGS
-# =============================================================================
-
-# Enable/Disable Features
-FEATURE_DEVICE_VALIDATION=True
-FEATURE_BATCH_ASSIGNMENT=False
-FEATURE_ADMIN_DASHBOARD=False
-
-# =============================================================================
-# PERFORMANCE TUNING
-# =============================================================================
-
-# Caching
-CACHE_TYPE=simple
-CACHE_DEFAULT_TIMEOUT=300
-
-# Request Timeout (seconds)
-REQUEST_TIMEOUT=30
-
-# API Rate Limiting
-API_RATE_LIMIT=100
-API_RATE_PERIOD=3600
-
-# =============================================================================
-# NOTES
-# =============================================================================
-
-# 1. All sensitive values should be generated randomly and kept secure
-# 2. Rotate secrets regularly (recommend quarterly)
-# 3. Use different values for each environment (dev/staging/prod)
-# 4. Store production secrets in secure key management systems
-# 5. Never commit the actual .env file to version control
-# 6. Review and audit environment variables regularly
-# 7. Follow your organization's security policies for secret management
+# SECRET_KEY=your_flask_secret_key_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,144 +2,44 @@
 
 All notable changes to DEPAAD will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Added
-- Comprehensive README.md with enterprise security documentation
-- Environment configuration template (.env.example)
-- Contributing guidelines (CONTRIBUTING.md)
-- MIT License
-- Enhanced .gitignore with Flask-specific exclusions
-- Project documentation and GitHub templates
-
-### Changed
-- Updated .gitignore to exclude flask_session/ and logs/ directories
-- Enhanced security documentation and best practices
-
-### Security
-- Added security best practices documentation
-- Environment variable configuration for sensitive data
-- Security guidelines for contributors
-
 ## [0.2.0] - 2024-01-15
 
 ### Added
-- Heroku deployment configuration
+- Heroku deployment configuration and Procfile
 - Production logging with rotation
-- Session management improvements
-- Error handling enhancements
+- Comprehensive project documentation
+- Environment configuration template (.env.example)
 
 ### Changed
-- Updated Procfile for Heroku deployment
-- Modified routes for production environment
-- Enhanced error pages and templates
+- Enhanced error handling and user experience
+- Updated templates and UI components
+- Improved session management for production
 
 ### Fixed
-- Session storage issues in production
-- Logging configuration for Heroku
+- Session storage issues in production environment
 - Device assignment workflow improvements
+- Logging configuration for Heroku deployment
 
 ## [0.1.0] - 2023-12-01
 
 ### Added
-- Initial release of DEPAAD
-- Microsoft Azure AD OAuth2 authentication
-- MobileIron Cloud API integration
-- iOS device detection and validation
-- Device assignment automation
-- Flask web application framework
-- Session management with Flask-Session
-- Basic error handling and logging
-- HTML templates with CoreUI styling
+- Initial release - Multi-user DEP device support for MobileIron Cloud
+- Azure AD OAuth2 authentication with MSAL
+- MobileIron Cloud API integration for device assignment
+- iOS device detection and webclip parameter handling
+- Flask web application with session management
+- Automated device-to-user assignment workflow
 
 ### Features
-- **Authentication Flow**
-  - Azure AD OAuth2 integration with MSAL
-  - Secure token management
-  - Session-based authentication state
-  
-- **Device Management**
-  - MobileIron Cloud API integration
-  - Device search by serial number
-  - Automated device-to-user assignment
-  - iOS platform detection
-  
-- **Web Interface**
-  - Responsive HTML templates
-  - Login/logout functionality
-  - Device assignment status pages
-  - Error handling pages
-  
-- **Security**
-  - Environment variable configuration
-  - Secure session management
-  - OAuth2 state validation
-  - Input validation and sanitization
-  
-- **Infrastructure**
-  - Flask application with modular structure
-  - Configuration management
-  - Logging system
-  - Production-ready deployment structure
+- **Webclip Integration**: Device serial passed automatically via MobileIron webclip
+- **Azure Authentication**: Secure OAuth2 flow with Microsoft Identity Platform  
+- **Device Assignment**: Automatic assignment of DEP devices to authenticated users
+- **iOS Detection**: Platform validation to restrict access to iOS devices only
+- **Session Security**: Filesystem-based session storage with state validation
 
-### Technical Implementation
-- **Backend**: Python 3.7.9 with Flask 1.1.2
-- **Authentication**: Microsoft Authentication Library (MSAL)
-- **Session Storage**: Filesystem-based sessions
-- **API Integration**: MobileIron Cloud REST API
-- **Frontend**: HTML templates with CoreUI CSS framework
-- **Deployment**: Heroku-ready with Procfile and requirements.txt
-
-### Security Measures
-- Client secrets stored in environment variables
-- API tokens secured with Base64 encoding
-- CSRF protection through OAuth2 state parameter
-- Session security with filesystem storage
-- Input validation for device serial numbers
-- Error handling without information disclosure
-
----
-
-## Release Notes Format
-
-### Categories
-- **Added**: New features
-- **Changed**: Changes in existing functionality
-- **Deprecated**: Soon-to-be removed features
-- **Removed**: Now removed features
-- **Fixed**: Any bug fixes
-- **Security**: Vulnerability fixes and security improvements
-
-### Version Numbers
-- **Major** (X.0.0): Breaking changes or major new features
-- **Minor** (0.X.0): New features, backward compatible
-- **Patch** (0.0.X): Bug fixes, backward compatible
-
-### Example Entry Format
-```markdown
-## [1.2.3] - 2024-02-15
-
-### Added
-- New feature description with details
-- Another feature with [#123](link-to-issue)
-
-### Changed
-- Modified existing feature behavior
-- Updated dependency versions
-
-### Fixed
-- Fixed bug description [#456](link-to-issue)
-- Resolved security vulnerability
-
-### Security
-- Updated authentication mechanism
-- Enhanced input validation
-```
-
-### Links
-- [Unreleased]: https://github.com/vcruzcid/DEPAAD/compare/v0.2.0...HEAD
-- [0.2.0]: https://github.com/vcruzcid/DEPAAD/compare/v0.1.0...v0.2.0
-- [0.1.0]: https://github.com/vcruzcid/DEPAAD/releases/tag/v0.1.0
+### Technical Details
+- Python 3.7.9 with Flask 1.1.2
+- Microsoft Authentication Library (MSAL) for OAuth2
+- MobileIron Cloud REST API integration
+- CoreUI-based responsive templates
+- Environment-based configuration management

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,433 +1,112 @@
 # Contributing to DEPAAD
 
-Thank you for your interest in contributing to DEPAAD! This document provides guidelines and information for contributors.
+Thank you for your interest in contributing to DEPAAD!
 
-## 📋 Table of Contents
-
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Environment](#development-environment)
-- [Contributing Process](#contributing-process)
-- [Coding Standards](#coding-standards)
-- [Security Guidelines](#security-guidelines)
-- [Testing Requirements](#testing-requirements)
-- [Pull Request Process](#pull-request-process)
-- [Issue Guidelines](#issue-guidelines)
-- [License](#license)
-
-## 🤝 Code of Conduct
-
-By participating in this project, you agree to abide by our Code of Conduct:
-
-- **Be respectful**: Treat all contributors with respect and courtesy
-- **Be inclusive**: Welcome contributors of all backgrounds and skill levels
-- **Be constructive**: Provide helpful feedback and suggestions
-- **Be professional**: Maintain professional communication standards
-- **Be secure**: Follow security best practices in all contributions
-
-## 🚀 Getting Started
+## Getting Started
 
 ### Prerequisites
-
-- Python 3.7.9 or higher
-- Git (latest version)
+- Python 3.7.9+
 - Access to Azure AD tenant (for testing)
 - MobileIron Cloud instance (for integration testing)
 
-### Fork and Clone
+### Development Setup
 
-1. Fork the repository on GitHub
-2. Clone your fork locally:
+1. **Fork and clone**:
    ```bash
    git clone https://github.com/YOUR_USERNAME/DEPAAD.git
    cd DEPAAD
-   ```
-3. Add the original repository as upstream:
-   ```bash
    git remote add upstream https://github.com/vcruzcid/DEPAAD.git
    ```
 
-## 🛠️ Development Environment
-
-### Local Setup
-
-1. **Create virtual environment**:
+2. **Setup environment**:
    ```bash
    python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   ```
-
-2. **Install dependencies**:
-   ```bash
+   source venv/bin/activate
    pip install -r requirements.txt
-   pip install -r requirements-dev.txt  # If available
-   ```
-
-3. **Configure environment**:
-   ```bash
    cp .env.example .env
    # Edit .env with your development values
    ```
 
-4. **Install pre-commit hooks** (recommended):
-   ```bash
-   pre-commit install
-   ```
+## Development Guidelines
 
-### IDE Configuration
-
-#### Visual Studio Code
-Create `.vscode/settings.json`:
-```json
-{
-  "python.defaultInterpreterPath": "./venv/bin/python",
-  "python.linting.enabled": true,
-  "python.linting.flake8Enabled": true,
-  "python.linting.pylintEnabled": true,
-  "python.formatting.provider": "autopep8",
-  "python.testing.pytestEnabled": true,
-  "files.exclude": {
-    "**/__pycache__": true,
-    "**/*.pyc": true,
-    ".venv": true,
-    "flask_session": true
-  }
-}
-```
-
-## 🔄 Contributing Process
-
-### Git Flow Workflow
-
-We use Git Flow for branch management:
-
-- **`main`**: Production-ready code
-- **`develop`**: Integration branch for features
-- **`feature/*`**: New features or enhancements
-- **`hotfix/*`**: Critical bug fixes for production
-- **`release/*`**: Release preparation
-
-### Branch Naming Convention
-
-- Features: `feature/issue-number-short-description`
-- Bug fixes: `bugfix/issue-number-short-description`
-- Hotfixes: `hotfix/issue-number-short-description`
-- Documentation: `docs/short-description`
-
-Examples:
-- `feature/123-azure-ad-groups`
-- `bugfix/456-session-timeout`
-- `hotfix/789-security-vulnerability`
-
-### Commit Message Format
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>[optional scope]: <description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
-Types:
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, etc.)
-- `refactor`: Code refactoring
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
-
-Examples:
-```
-feat(auth): add support for Azure AD groups
-fix(api): handle MobileIron API timeout errors
-docs: update deployment instructions
-test(auth): add integration tests for OAuth flow
-```
-
-## 📏 Coding Standards
-
-### Python Style Guide
-
-- Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/)
-- Use [Black](https://black.readthedocs.io/) for code formatting
-- Maximum line length: 88 characters
-- Use type hints where appropriate
-
-### Code Quality Tools
-
-Run these tools before submitting:
-
-```bash
-# Code formatting
-black app/ tests/
-
-# Import sorting
-isort app/ tests/
-
-# Linting
-flake8 app/ tests/
-pylint app/ tests/
-
-# Type checking (if using mypy)
-mypy app/
-
-# Security scanning
-bandit -r app/
-safety check
-```
-
-### Documentation Standards
-
-- Write clear, concise docstrings for all functions and classes
-- Use Google-style docstrings
-- Update README.md for significant changes
-- Include inline comments for complex logic
-
-Example docstring:
-```python
-def assign_device(userid: str, deviceid: str) -> requests.Response:
-    """Assign a device to a user in MobileIron Cloud.
-    
-    This function makes an API call to MobileIron Cloud to associate
-    a specific device with a user account.
-    
-    Args:
-        userid (str): The MobileIron user account ID
-        deviceid (str): The device ID to assign
-        
-    Returns:
-        requests.Response: The API response object
-        
-    Raises:
-        requests.RequestException: If the API call fails
-        ValueError: If userid or deviceid is invalid
-    """
-```
-
-## 🔒 Security Guidelines
+### Code Style
+- Follow PEP 8 Python style guide
+- Use meaningful variable and function names
+- Add docstrings for functions and classes
+- Keep functions focused and small
 
 ### Security Requirements
+- **Never commit secrets** - Use environment variables
+- Validate all user inputs
+- Handle errors gracefully without exposing sensitive information
+- Follow secure session management practices
 
-- **Never commit secrets**: Use environment variables for sensitive data
-- **Input validation**: Validate all user inputs
-- **Output encoding**: Properly encode outputs to prevent XSS
-- **Authentication**: Maintain secure session management
-- **Authorization**: Implement proper access controls
-- **Logging**: Log security events without exposing sensitive data
-
-### Security Checklist
-
-Before submitting code, ensure:
-
-- [ ] No hardcoded secrets or credentials
-- [ ] Input validation for all user data
-- [ ] Proper error handling without information disclosure
-- [ ] Secure session management
-- [ ] HTTPS enforcement in production
-- [ ] Dependencies are up to date
-- [ ] Security headers are properly configured
-
-### Vulnerability Reporting
-
-Report security vulnerabilities privately to: security@company.com
-
-Do not create public issues for security vulnerabilities.
-
-## 🧪 Testing Requirements
-
-### Test Categories
-
-1. **Unit Tests**: Test individual functions and classes
-2. **Integration Tests**: Test component interactions
-3. **Security Tests**: Test security controls
-4. **End-to-End Tests**: Test complete workflows
-
-### Running Tests
-
+### Testing
 ```bash
-# Run all tests
-python -m pytest
+# Run the application locally
+python app/app.py
 
-# Run with coverage
-python -m pytest --cov=app --cov-report=html
-
-# Run specific test categories
-python -m pytest tests/unit/
-python -m pytest tests/integration/
-python -m pytest tests/security/
-
-# Run performance tests
-python -m pytest tests/performance/ --benchmark-only
+# Test with different scenarios:
+# - iOS device access with valid serial
+# - Non-iOS device access (should be blocked)
+# - Invalid device serial handling
+# - Azure AD authentication flow
 ```
 
-### Test Standards
+## Contributing Process
 
-- Maintain minimum 80% code coverage
-- Write descriptive test names
-- Use fixtures for common test data
-- Mock external dependencies
-- Test both success and failure scenarios
+### Branch Strategy
+- `main`: Production code
+- `develop`: Integration branch
+- `feature/description`: New features
+- `bugfix/description`: Bug fixes
 
-Example test structure:
-```python
-def test_assign_device_success():
-    """Test successful device assignment."""
-    # Arrange
-    userid = "test-user-123"
-    deviceid = "test-device-456"
-    
-    # Act
-    result = assign_device(userid, deviceid)
-    
-    # Assert
-    assert result.status_code == 200
-    assert "success" in result.json()
+### Commit Messages
+Use clear, descriptive commit messages:
+```
+feat: add device validation for non-iOS platforms
+fix: handle MobileIron API timeout errors
+docs: update configuration instructions
 ```
 
-## 📝 Pull Request Process
+### Pull Request Process
 
-### Before Submitting
-
-1. **Update your fork**:
+1. **Create feature branch**:
    ```bash
-   git fetch upstream
    git checkout develop
-   git merge upstream/develop
+   git checkout -b feature/your-feature
    ```
 
-2. **Create feature branch**:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-
-3. **Make your changes**:
+2. **Make changes and test**:
    - Follow coding standards
-   - Add tests for new functionality
-   - Update documentation as needed
+   - Test your changes thoroughly
+   - Update documentation if needed
 
-4. **Test your changes**:
-   ```bash
-   python -m pytest
-   flake8 app/ tests/
-   bandit -r app/
-   ```
+3. **Submit pull request**:
+   - Target the `develop` branch
+   - Include clear description of changes
+   - Reference any related issues
 
-5. **Commit your changes**:
-   ```bash
-   git add .
-   git commit -m "feat: add your feature description"
-   ```
-
-6. **Push to your fork**:
-   ```bash
-   git push origin feature/your-feature-name
-   ```
-
-### Pull Request Template
-
-When creating a PR, include:
-
-```markdown
-## Description
-Brief description of changes made.
-
-## Type of Change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-
-## Testing
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] I have tested this change manually
-
-## Security
-- [ ] I have reviewed my code for security vulnerabilities
-- [ ] No sensitive information is exposed
-- [ ] Input validation is implemented where needed
-
-## Checklist
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-```
-
-### Review Process
-
-1. **Automated Checks**: CI/CD pipeline runs tests and security scans
-2. **Code Review**: At least one maintainer reviews the code
-3. **Security Review**: Security-sensitive changes require additional review
-4. **Testing**: Manual testing may be required for significant changes
-5. **Approval**: PR must be approved before merging
-
-### Merge Strategy
-
-- Feature branches merge into `develop`
-- `develop` merges into `main` for releases
-- Squash commits for cleaner history
-- Delete feature branches after merge
-
-## 🐛 Issue Guidelines
+## Issue Reporting
 
 ### Bug Reports
-
-Use the bug report template and include:
-
-- **Description**: Clear description of the bug
-- **Steps to Reproduce**: Detailed reproduction steps
-- **Expected Behavior**: What should happen
-- **Actual Behavior**: What actually happens
-- **Environment**: OS, Python version, browser, etc.
-- **Screenshots**: If applicable
-- **Error Messages**: Full error messages and stack traces
+Include:
+- Clear description of the issue
+- Steps to reproduce
+- Expected vs actual behavior
+- Environment details (OS, Python version, browser)
+- Error messages or screenshots
 
 ### Feature Requests
+Include:
+- Problem statement
+- Proposed solution
+- Use cases and benefits
 
-Use the feature request template and include:
+## Security
 
-- **Problem Statement**: What problem does this solve?
-- **Proposed Solution**: How should it work?
-- **Alternatives**: Other solutions considered
-- **Use Cases**: How would this be used?
-- **Priority**: Business impact and urgency
+Report security vulnerabilities privately via GitHub security advisories or email maintainers directly. Do not create public issues for security problems.
 
-### Labels
+## License
 
-We use these labels for issue management:
-
-- `bug`: Something isn't working
-- `enhancement`: New feature or request
-- `documentation`: Improvements or additions to documentation
-- `good first issue`: Good for newcomers
-- `help wanted`: Extra attention is needed
-- `priority:high`: High priority items
-- `security`: Security-related issues
-
-## 📄 License
-
-By contributing to DEPAAD, you agree that your contributions will be licensed under the MIT License.
-
-## 🤔 Questions?
-
-- Check existing issues and discussions
-- Review project documentation
-- Contact maintainers via GitHub issues
-- Join our development chat (if available)
-
-## 🙏 Recognition
-
-Contributors are recognized in:
-
-- `CONTRIBUTORS.md` file
-- Release notes for significant contributions
-- Project documentation
-- Annual contributor appreciation
-
-Thank you for contributing to DEPAAD! 🚀
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -4,305 +4,104 @@
 [![Flask Version](https://img.shields.io/badge/flask-1.1.2-green.svg)](https://flask.palletsprojects.com/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-DEPAAD is an enterprise-grade Flask web application that automates iOS device provisioning and user assignment through Microsoft Azure Active Directory authentication and MobileIron Cloud device management integration.
+DEPAAD enables multi-user support for DEP devices in MobileIron Cloud by automating device assignment through Azure AD authentication via webclip deployment.
 
-## 🚀 Features
+## How It Works
 
-- **Azure AD Authentication**: Secure OAuth2 flow using Microsoft Identity Platform
-- **Automated Device Assignment**: Seamless integration with MobileIron Cloud API
-- **iOS Device Detection**: Intelligent platform detection for iOS devices
-- **Enterprise Security**: Built-in security controls and audit logging
-- **Session Management**: Secure filesystem-based session handling
-- **Production Ready**: Heroku deployment with comprehensive monitoring
+1. **Webclip Deployment**: MobileIron pushes a webclip to iOS devices with device serial as URL parameter
+2. **User Authentication**: User taps webclip, authenticates with Azure AD
+3. **Automatic Assignment**: App assigns device to authenticated user in MobileIron Cloud
 
-## 🏗️ Architecture
+## Architecture
 
 ```
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────────┐
-│   iOS Device    │───▶│   DEPAAD App     │───▶│  MobileIron Cloud   │
-│                 │    │                  │    │                     │
-└─────────────────┘    └──────────────────┘    └─────────────────────┘
-                              │
-                              ▼
-                    ┌──────────────────┐
-                    │  Microsoft       │
-                    │  Azure AD        │
-                    └──────────────────┘
+iOS Device → Webclip (w/ serial) → DEPAAD App → Azure AD Authentication → MobileIron Cloud Assignment
 ```
 
-### Core Components
-
-| Component | Purpose | Location |
-|-----------|---------|----------|
-| **Flask App** | Main application routes and logic | `app/app.py` |
-| **MS Authentication** | Azure AD OAuth2 integration | `app/functions/ms_auth.py` |
-| **MobileIron Integration** | Device management API calls | `app/functions/mi_cloud.py` |
-| **Utilities** | Helper functions and validation | `app/functions/ps_common.py` |
-| **Configuration** | Environment-based settings | `app/conf/app_config.py` |
-
-## 📋 Prerequisites
+## Prerequisites
 
 - Python 3.7.9+
-- Flask 1.1.2+
-- Microsoft Azure AD tenant with app registration
+- Azure AD tenant with app registration
 - MobileIron Cloud instance with API access
-- iOS device for testing
 
-## 🔧 Installation
+## Quick Start
 
-### Local Development
-
-1. **Clone the repository**
+1. **Clone and setup**
    ```bash
    git clone https://github.com/vcruzcid/DEPAAD.git
    cd DEPAAD
-   ```
-
-2. **Create virtual environment**
-   ```bash
    python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   ```
-
-3. **Install dependencies**
-   ```bash
+   source venv/bin/activate
    pip install -r requirements.txt
    ```
 
-4. **Configure environment variables**
+2. **Configure environment**
    ```bash
    cp .env.example .env
-   # Edit .env with your configuration values
+   # Edit .env with your Azure and MobileIron credentials
    ```
 
-5. **Run the application**
+3. **Run**
    ```bash
    python app/app.py
    ```
 
-### Production Deployment (Heroku)
-
-1. **Deploy to Heroku**
-   ```bash
-   heroku create your-app-name
-   heroku config:set CLIENT_SECRET=your_client_secret
-   heroku config:set API_TOKEN=your_api_token
-   git push heroku develop:master
-   ```
-
-## ⚙️ Configuration
+## Configuration
 
 ### Environment Variables
 
-Create a `.env` file based on `.env.example`:
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `CLIENT_SECRET` | Azure AD app client secret | ✅ |
+| `API_TOKEN` | MobileIron Cloud API token (Base64) | ✅ |
 
-| Variable | Description | Required | Example |
-|----------|-------------|----------|---------|
-| `CLIENT_SECRET` | Azure AD app client secret | ✅ | `your-azure-client-secret` |
-| `API_TOKEN` | MobileIron Cloud API token (Base64) | ✅ | `your-base64-encoded-token` |
-| `FLASK_ENV` | Flask environment | ❌ | `production` |
-| `SECRET_KEY` | Flask session secret key | ❌ | `your-secret-key` |
+### Azure AD Setup
 
-### Azure AD App Registration
+1. Create app registration in Azure Portal
+2. Set redirect URI: `https://your-domain.com/getAADToken`
+3. Generate client secret
+4. Update `CLIENT_ID` in `app/conf/app_config.py` (currently: `98145980-4a60-455a-9699-eacf4d339ee8`)
 
-1. Navigate to [Azure Portal](https://portal.azure.com) → Azure Active Directory → App registrations
-2. Create new registration with these settings:
-   - **Name**: DEPAAD
-   - **Redirect URI**: `https://your-domain.com/getAADToken`
-   - **Client Secret**: Generate and store securely
-3. Note the **Application (client) ID**: `98145980-4a60-455a-9699-eacf4d339ee8`
+### MobileIron Setup
 
-### MobileIron Cloud Setup
+1. Generate API token in MobileIron Cloud Admin Portal
+2. Base64 encode the token for `API_TOKEN` environment variable
+3. Deploy webclip with URL: `https://your-app.com/?deviceSerial={DEVICE_SERIAL}`
 
-1. Navigate to MobileIron Cloud Admin Portal
-2. Generate API token: **Admin** → **API** → **Generate Token**
-3. Encode token in Base64 format for `API_TOKEN` environment variable
+## Security Features
 
-## 🔐 Security Best Practices
+- iOS device restriction via user-agent detection
+- Azure AD OAuth2 authentication with state validation
+- Secure session management with filesystem storage
+- Environment-based secret management
 
-### Authentication & Authorization
+## Deployment
 
-- **OAuth2 Flow**: Implements secure authorization code flow with PKCE
-- **Token Management**: Tokens stored in secure server-side sessions
-- **Session Security**: Filesystem-based sessions with automatic cleanup
-- **State Validation**: CSRF protection through state parameter validation
-
-### Data Protection
-
-- **Environment Variables**: Sensitive data stored in environment variables
-- **Secret Management**: Client secrets never logged or exposed
-- **HTTPS Enforcement**: All production traffic encrypted in transit
-- **Input Validation**: User inputs sanitized and validated
-
-### Infrastructure Security
-
-- **Heroku Platform**: PCI DSS Level 1 compliant hosting
-- **Session Storage**: Secure filesystem sessions (not in-memory)
-- **Logging**: Structured logging without sensitive data exposure
-- **Error Handling**: Graceful error handling without information disclosure
-
-### Compliance Considerations
-
-- **GDPR**: User data handling with consent mechanisms
-- **SOX**: Audit trails for device assignments
-- **HIPAA**: Secure session management and data encryption
-- **SOC 2**: Comprehensive security controls and monitoring
-
-## 📊 Monitoring & Observability
-
-### Application Metrics
-
-- **Response Times**: Average response time < 200ms
-- **Error Rates**: Error rate < 1%
-- **Uptime**: 99.9% availability SLA
-- **Session Management**: Active session monitoring
-
-### Logging Strategy
-
-```python
-# Structured logging format
-{
-  "timestamp": "2024-01-15T10:30:00Z",
-  "level": "INFO",
-  "message": "Device assignment completed",
-  "user": "user@company.com",
-  "device_serial": "ABC123456",
-  "request_id": "req-123-456"
-}
-```
-
-### Health Checks
-
-- **Application Health**: `/health` endpoint (implement if needed)
-- **Database Connectivity**: Session store accessibility
-- **External Dependencies**: Azure AD and MobileIron API availability
-
-## 🔄 Workflow
-
-### Device Assignment Process
-
-```mermaid
-sequenceDiagram
-    participant U as User (iOS)
-    participant D as DEPAAD
-    participant A as Azure AD
-    participant M as MobileIron
-
-    U->>D: Access with device serial
-    D->>D: Validate iOS device
-    D->>A: Redirect to OAuth2 login
-    A->>U: Present login form
-    U->>A: Authenticate
-    A->>D: Return with auth code
-    D->>A: Exchange code for token
-    D->>M: Search device by serial
-    M->>D: Return device details
-    D->>M: Assign device to user
-    D->>U: Display success message
-```
-
-### Error Handling
-
-1. **Device Not Found**: User redirected to error page with support contact
-2. **Authentication Failure**: Clear error message with retry option
-3. **API Errors**: Graceful degradation with fallback mechanisms
-4. **Network Issues**: Automatic retry with exponential backoff
-
-## 🧪 Testing
-
-### Unit Tests
+### Heroku
 ```bash
-python -m pytest tests/unit/
+heroku create your-app-name
+heroku config:set CLIENT_SECRET=your_client_secret
+heroku config:set API_TOKEN=your_api_token
+git push heroku develop:master
 ```
 
-### Integration Tests
-```bash
-python -m pytest tests/integration/
-```
+## Troubleshooting
 
-### Security Tests
-```bash
-# Run security checks
-bandit -r app/
-safety check
-```
+| Issue | Solution |
+|-------|----------|
+| Authentication fails | Verify `CLIENT_SECRET` environment variable |
+| Device not found | Check device serial in MobileIron inventory |
+| API errors | Regenerate and update `API_TOKEN` |
 
-## 📈 Performance
+## Contributing
 
-### Optimization Strategies
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 
-- **Session Caching**: Efficient token cache management
-- **API Rate Limiting**: Respectful API usage patterns
-- **Error Caching**: Prevent repeated failed API calls
-- **Resource Cleanup**: Automatic session cleanup
+## License
 
-### Scalability Considerations
-
-- **Horizontal Scaling**: Stateless application design
-- **Load Balancing**: Support for multiple application instances
-- **Database Connection Pooling**: Efficient resource utilization
-- **CDN Integration**: Static asset optimization
-
-## 🚨 Troubleshooting
-
-### Common Issues
-
-| Issue | Cause | Solution |
-|-------|-------|----------|
-| Authentication fails | Invalid client secret | Verify `CLIENT_SECRET` environment variable |
-| Device not found | Serial number mismatch | Check device serial format and MobileIron inventory |
-| API errors | Invalid token | Regenerate and update `API_TOKEN` |
-| Session issues | Filesystem permissions | Check `flask_session/` directory permissions |
-
-### Debugging
-
-1. **Enable Debug Logging**
-   ```bash
-   export FLASK_ENV=development
-   export FLASK_DEBUG=1
-   ```
-
-2. **Check Application Logs**
-   ```bash
-   tail -f logs/depaad.log
-   ```
-
-3. **Validate Configuration**
-   ```bash
-   python -c "from app.conf import app_config; print('Config loaded successfully')"
-   ```
-
-## 🤝 Contributing
-
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.
-
-### Development Workflow
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🆘 Support
-
-- **Documentation**: [Wiki](https://github.com/vcruzcid/DEPAAD/wiki)
-- **Issues**: [GitHub Issues](https://github.com/vcruzcid/DEPAAD/issues)
-- **Security**: Report security vulnerabilities to security@company.com
-
-## 📚 Additional Resources
-
-- [Azure AD Documentation](https://docs.microsoft.com/en-us/azure/active-directory/)
-- [MobileIron Cloud API](https://help.mobileiron.com/s/article/ka1340000005PCIAA2/Cloud-API-Overview)
-- [Flask Security Guidelines](https://flask.palletsprojects.com/en/2.0.x/security/)
-- [OWASP Web Security](https://owasp.org/www-project-top-ten/)
+MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
 **Version**: 0.2.0  
-**Last Updated**: January 2024  
 **Maintainer**: [vcruzcid](https://github.com/vcruzcid)


### PR DESCRIPTION
## Summary
- Simplified README.md to focus on core webclip deployment functionality and multi-user DEP support
- Reduced .env.example from 198 to 27 lines with only essential configuration variables
- Streamlined CHANGELOG.md to highlight actual implemented features instead of enterprise overhead
- Condensed CONTRIBUTING.md to practical development guidelines

## Changes Made
- **README.md**: Removed enterprise-heavy sections, focused on webclip deployment mechanism
- **.env.example**: Kept only required `CLIENT_SECRET` and `API_TOKEN` variables
- **CHANGELOG.md**: Simplified to reflect actual project history and features
- **CONTRIBUTING.md**: Reduced from 433 to 112 lines with essential development info

## Why These Changes
The documentation was overly complex for what is essentially a focused tool for enabling multi-user DEP device support through webclip deployment and Azure AD authentication. This streamlines the docs to match the actual project scope and functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)